### PR TITLE
Add flags and port wiring to expose validator monitoring

### DIFF
--- a/docker-compose-syslog.yml
+++ b/docker-compose-syslog.yml
@@ -10,6 +10,7 @@ services:
       --config-file /root/sbc/config/config.yml
       --chain-config-file /root/sbc/config/config.yml
       --rpc-host 0.0.0.0
+      --grpc-gateway-host 0.0.0.0
       --p2p-local-ip 0.0.0.0
       --p2p-host-ip $PUBLIC_IP
       --subscribe-all-subnets
@@ -55,6 +56,11 @@ services:
       --chain-config-file /root/sbc/config/config.yml
       --wallet-password-file /root/sbc/keys/wallet_password.txt
       --beacon-rpc-provider node:4000
+      --grpc-gateway-host 0.0.0.0
+      --monitoring-host 0.0.0.0
+    ports:
+      - '7500:7500'
+      - '127.0.0.1:8081:8081'
     volumes:
       - ./config:/root/sbc/config
       - ./keys:/root/sbc/keys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,11 @@ services:
       --chain-config-file /root/sbc/config/config.yml
       --wallet-password-file /root/sbc/keys/wallet_password.txt
       --beacon-rpc-provider node:4000
+      --grpc-gateway-host 0.0.0.0
+      --monitoring-host 0.0.0.0
+    ports:
+      - '7500:7500'
+      - '127.0.0.1:8081:8081'
     volumes:
       - ./config:/root/sbc/config
       - ./keys:/root/sbc/keys


### PR DESCRIPTION
With current docker-compose configuration is not possible to add Prometheus monitoring for the validator out of the box. We need to expose port 8081 same way we expose port 8080 in the beacon-chain-node

It also adds wiring for port 7500 that is used to load Prysm web interface adding `--web` flag in validator command